### PR TITLE
[최건]일정을 프로젝트 -> 팀으로 변경 프로젝트 - 팀 1대1로 변경

### DIFF
--- a/src/main/java/com/beyond/backend/config/SchedulerConfiguration.java
+++ b/src/main/java/com/beyond/backend/config/SchedulerConfiguration.java
@@ -1,6 +1,6 @@
 package com.beyond.backend.config;
 
-import com.beyond.backend.domain.project.service.ScheduleService;
+import com.beyond.backend.domain.team.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/src/main/java/com/beyond/backend/controller/ScheduleController.java
+++ b/src/main/java/com/beyond/backend/controller/ScheduleController.java
@@ -2,7 +2,7 @@ package com.beyond.backend.controller;
 
 import com.beyond.backend.domain.project.dto.ScheduleRequestDto;
 import com.beyond.backend.domain.project.dto.ScheduleResponseDto;
-import com.beyond.backend.domain.project.service.ScheduleService;
+import com.beyond.backend.domain.team.service.ScheduleService;
 import com.beyond.backend.domain.user.dto.CustomUserDetails;
 import com.beyond.backend.domain.user.service.AuthService;
 import jakarta.validation.Valid;
@@ -65,13 +65,13 @@ public class ScheduleController {
         return ResponseEntity.ok(responseDto);
     }
 
-    @GetMapping("/project/{projectId}")
-    public ResponseEntity<List<ScheduleResponseDto>> getSchedulesByProject(
-            @PathVariable Long projectId,
+    @GetMapping("/team/{teamNo}")
+    public ResponseEntity<List<ScheduleResponseDto>> getSchedulesByTeam(
+            @PathVariable Long teamNo,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long userNo = userDetails.getUser().getNo();
-        List<ScheduleResponseDto> schedules = scheduleService.getSchedulesByProject(projectId, userNo);
+        List<ScheduleResponseDto> schedules = scheduleService.getSchedulesByTeam(teamNo, userNo);
         return ResponseEntity.ok(schedules);
     }
 }

--- a/src/main/java/com/beyond/backend/domain/project/dto/AlertResponseDto.java
+++ b/src/main/java/com/beyond/backend/domain/project/dto/AlertResponseDto.java
@@ -1,10 +1,12 @@
 package com.beyond.backend.domain.project.dto;
 
-import com.beyond.backend.domain.project.entity.Schedule;
-import com.beyond.backend.domain.user.entity.User;
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
+@AllArgsConstructor
 public class AlertResponseDto {
 
     Long receiverNo;

--- a/src/main/java/com/beyond/backend/domain/project/dto/ScheduleRequestDto.java
+++ b/src/main/java/com/beyond/backend/domain/project/dto/ScheduleRequestDto.java
@@ -8,7 +8,7 @@ import java.time.LocalDateTime;
 @Data
 public class ScheduleRequestDto {
 
-    Long projectId;
+    Long teamNo;
 
     @NotBlank
     private String title;

--- a/src/main/java/com/beyond/backend/domain/project/entity/Project.java
+++ b/src/main/java/com/beyond/backend/domain/project/entity/Project.java
@@ -8,28 +8,11 @@ import com.beyond.backend.domain.feedback.entity.Feedback;
 import com.beyond.backend.domain.project.dto.ProjectUpdateRequestDto;
 import com.beyond.backend.domain.team.entity.Team;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.Table;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import jakarta.persistence.*;
+import lombok.*;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "project")
@@ -45,10 +28,10 @@ public class Project extends BaseEntity {
     // 프로젝트 내용/설명
     private String content;
 
-    @Column(nullable = false)
-    private int viewCnt;
+    private int viewCnt = 0;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @Setter
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "team_no")
     private Team team;
 
@@ -61,24 +44,13 @@ public class Project extends BaseEntity {
     @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ProjectTech> projectTeches = new ArrayList<>();
 
-    @OneToMany(mappedBy = "project", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Schedule> schedules = new ArrayList<>();
 
-    //기본 초기화
-    @PrePersist
-    public void prePersist() {
-        if (projectStatus == null) {
-            projectStatus = ProjectStatus.OPEN;
-        }
-    }
-
-
-    //== 연관관계 편의 메서드 ==//
-    public void setTeam(Team team){
-        this.team = team; // 프로젝트의 팀을 설정
-        if (!team.getProjects().contains(this)){
-            team.getProjects().add(this);
-        }
+    @Builder
+    public Project(String name, String content, Team team) {
+        this.name = name;
+        this.content = content;
+        this.team = team;
+        this.projectStatus = ProjectStatus.OPEN;
     }
 
 

--- a/src/main/java/com/beyond/backend/domain/project/entity/Schedule.java
+++ b/src/main/java/com/beyond/backend/domain/project/entity/Schedule.java
@@ -1,6 +1,7 @@
 package com.beyond.backend.domain.project.entity;
 
 import com.beyond.backend.domain.common.Base;
+import com.beyond.backend.domain.team.entity.Team;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -28,14 +29,14 @@ public class Schedule extends Base {
     private ScheduleStatus status;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "project_id")
-    private Project project;
+    @JoinColumn(name = "team_no")
+    private Team team;
 
     private boolean isAlertSent;
 
     @Builder
-    public Schedule(String title, LocalDateTime startDate, LocalDateTime endDate, String description, Project project) {
-        this.project = project;
+    public Schedule(String title, LocalDateTime startDate, LocalDateTime endDate, String description, Team team) {
+        this.team = team;
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;

--- a/src/main/java/com/beyond/backend/domain/project/repository/ProjectRepositoryImpl.java
+++ b/src/main/java/com/beyond/backend/domain/project/repository/ProjectRepositoryImpl.java
@@ -145,7 +145,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 			.fetch()
 			.stream()
 			.collect(Collectors.groupingBy(
-				tuple -> tuple.get(projectTech.project.no), // projectId 기준으로 그룹화
+				tuple -> tuple.get(projectTech.project.no), // teamNo 기준으로 그룹화
 				Collectors.mapping(tuple -> tuple.get(projectTech.tech.techName), Collectors.toList()) // techName 리스트 매핑
 			));
 	}
@@ -196,7 +196,7 @@ public class ProjectRepositoryImpl implements ProjectRepositoryCustom {
 			))
 			.from(teamUser)
 			.join(teamUser.team, team) // 팀user <-> team 조인
-			.join(team.projects, project) // team <-> project 조인
+			.join(team.project, project) // team <-> project 조인
 			.where(teamUser.user.no.eq(userNo))
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize())

--- a/src/main/java/com/beyond/backend/domain/team/entity/Team.java
+++ b/src/main/java/com/beyond/backend/domain/team/entity/Team.java
@@ -1,6 +1,7 @@
 package com.beyond.backend.domain.team.entity;
 
 import com.beyond.backend.domain.common.BaseEntity;
+import com.beyond.backend.domain.project.entity.Schedule;
 import com.beyond.backend.domain.teamUser.entity.TeamUser;
 import com.beyond.backend.domain.project.entity.Project;
 import com.beyond.backend.domain.project.entity.ProjectStatus;
@@ -40,12 +41,15 @@ public class Team {
     private List<TeamUser> teamUsers = new ArrayList<>();
 
     // [홍도현] 25-02-26 팀-프로젝트 관계 수정
+    @OneToOne(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Project project;
+
     @OneToMany(mappedBy = "team", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Project> projects = new ArrayList<>();
+    private List<Schedule> schedules = new ArrayList<>();
 
     // [홍도현] 25-03-02 연관관계 편의 메서드
-    public void addProject(Project project){
-        this.projects.add(project);
+    public void setProject(Project project){
+        this.project = project;
         project.setTeam(this);
     }
 
@@ -53,6 +57,9 @@ public class Team {
         this.teamName = teamName;
         this.teamIntroduce = teamIntroduce;
         this.projectStatus = projectStatus;
+    }
 
+    public void addSchedule(Schedule schedule) {
+        this.schedules.add(schedule);
     }
 }

--- a/src/main/java/com/beyond/backend/domain/team/repository/ScheduleRepositoryCustom.java
+++ b/src/main/java/com/beyond/backend/domain/team/repository/ScheduleRepositoryCustom.java
@@ -1,4 +1,4 @@
-package com.beyond.backend.domain.project.repository;
+package com.beyond.backend.domain.team.repository;
 
 import com.beyond.backend.domain.project.dto.AlertResponseDto;
 

--- a/src/main/java/com/beyond/backend/domain/team/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/beyond/backend/domain/team/repository/ScheduleRepositoryImpl.java
@@ -1,4 +1,4 @@
-package com.beyond.backend.domain.project.repository;
+package com.beyond.backend.domain.team.repository;
 
 import com.beyond.backend.domain.project.dto.AlertResponseDto;
 import com.querydsl.core.types.Projections;
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static com.beyond.backend.domain.project.entity.QProject.project;
 import static com.beyond.backend.domain.project.entity.QSchedule.schedule;
 import static com.beyond.backend.domain.team.entity.QTeam.team;
 import static com.beyond.backend.domain.teamUser.entity.QTeamUser.teamUser;
@@ -35,8 +34,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom{
                 .from(schedule)
                 .where(schedule.endDate.between(now, nowPlus24),
                         schedule.isAlertSent.isFalse())
-                .join(schedule.project, project)
-                .join(project.team, team)
+                .join(schedule.team, team)
                 .join(team.teamUsers, teamUser)
                 .join(teamUser.user, user)
                 .fetch();

--- a/src/main/java/com/beyond/backend/domain/team/service/ScheduleService.java
+++ b/src/main/java/com/beyond/backend/domain/team/service/ScheduleService.java
@@ -1,9 +1,7 @@
-package com.beyond.backend.domain.project.service;
+package com.beyond.backend.domain.team.service;
 
 import com.beyond.backend.domain.project.dto.ScheduleRequestDto;
 import com.beyond.backend.domain.project.dto.ScheduleResponseDto;
-import com.beyond.backend.domain.project.entity.Schedule;
-import jakarta.persistence.EntityNotFoundException;
 
 import java.util.List;
 
@@ -17,7 +15,7 @@ public interface ScheduleService {
 
     ScheduleResponseDto getSchedule(Long scheduleId, Long userNo);
 
-    List<ScheduleResponseDto> getSchedulesByProject(Long scheduleId, Long userNo);
+    List<ScheduleResponseDto> getSchedulesByTeam(Long scheduleId, Long userNo);
 
     void sendAlert();
 

--- a/src/main/java/com/beyond/backend/domain/team/service/ScheduleServiceImpl.java
+++ b/src/main/java/com/beyond/backend/domain/team/service/ScheduleServiceImpl.java
@@ -1,4 +1,4 @@
-package com.beyond.backend.domain.project.service;
+package com.beyond.backend.domain.team.service;
 
 import com.beyond.backend.domain.common.dto.RequestNotificationDto;
 import com.beyond.backend.domain.common.entity.NotificationType;
@@ -6,11 +6,10 @@ import com.beyond.backend.domain.common.service.NotificationService;
 import com.beyond.backend.domain.project.dto.AlertResponseDto;
 import com.beyond.backend.domain.project.dto.ScheduleRequestDto;
 import com.beyond.backend.domain.project.dto.ScheduleResponseDto;
-import com.beyond.backend.domain.project.entity.Project;
 import com.beyond.backend.domain.project.entity.Schedule;
-import com.beyond.backend.domain.project.repository.ProjectRepository;
-import com.beyond.backend.domain.project.repository.ScheduleRepository;
-import com.beyond.backend.domain.teamUser.entity.TeamUser;
+import com.beyond.backend.domain.team.entity.Team;
+import com.beyond.backend.domain.team.repository.ScheduleRepository;
+import com.beyond.backend.domain.team.repository.TeamRepository;
 import com.beyond.backend.domain.user.entity.User;
 import com.beyond.backend.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -25,29 +24,29 @@ import java.util.List;
 public class ScheduleServiceImpl implements ScheduleService {
 
     private final ScheduleRepository scheduleRepository;
-    private final ProjectRepository projectRepository;
     private final UserRepository userRepository;
     private final NotificationService notificationService;
-
+    private final TeamRepository teamRepository;
 
     @Transactional
     public ScheduleResponseDto createSchedule(Long userNo, ScheduleRequestDto dto) {
 
         validateScheduleRequest(dto);
 
-        Project project = projectRepository.findById(dto.getProjectId())
-                .orElseThrow(() -> new IllegalArgumentException("project not found"));
+        Team team = teamRepository.findById(dto.getTeamNo())
+                .orElseThrow(() -> new IllegalArgumentException("team not found"));
 
         Schedule schedule = Schedule.builder()
                 .title(dto.getTitle())
                 .description(dto.getDescription())
                 .startDate(dto.getStartDate())
                 .endDate(dto.getEndDate())
+                .team(team)
                 .build();
 
-        project.getSchedules().add(schedule);
-
+        team.addSchedule(schedule);
         scheduleRepository.save(schedule);
+
         return new ScheduleResponseDto(schedule);
     }
 
@@ -61,8 +60,8 @@ public class ScheduleServiceImpl implements ScheduleService {
                 .orElseThrow(() -> new EntityNotFoundException("Schedule not found with id: " + scheduleId));
 
         // 프로젝트 접근 권한 확인 (선택적)
-        Project project = schedule.getProject();
-        validateUserAccessToProject(userNo, project);
+        Team team = schedule.getTeam();
+        validateUserAccessToTeam(userNo, team);
 
         // 일정 업데이트
         schedule.update(
@@ -78,15 +77,15 @@ public class ScheduleServiceImpl implements ScheduleService {
     public ScheduleResponseDto getSchedule(Long scheduleId, Long userNo){
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new EntityNotFoundException("Schedule not found with id: " + scheduleId));
-        validateUserAccessToProject(userNo, schedule.getProject());
+        validateUserAccessToTeam(userNo, schedule.getTeam());
 
         return new ScheduleResponseDto(schedule);
     }
 
-    public List<ScheduleResponseDto> getSchedulesByProject(Long scheduleId, Long userNo){
+    public List<ScheduleResponseDto> getSchedulesByTeam(Long scheduleId, Long userNo){
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new EntityNotFoundException("Schedule not found with id: " + scheduleId));
-        validateUserAccessToProject(userNo, schedule.getProject());
+        validateUserAccessToTeam(userNo, schedule.getTeam());
 
         return null;
     }
@@ -96,7 +95,7 @@ public class ScheduleServiceImpl implements ScheduleService {
     public void deleteSchedule(Long scheduleId, Long userNo) {
         Schedule schedule = scheduleRepository.findById(scheduleId)
                 .orElseThrow(() -> new EntityNotFoundException("Schedule not found with id: " + scheduleId));
-        validateUserAccessToProject(userNo, schedule.getProject());
+        validateUserAccessToTeam(userNo, schedule.getTeam());
         scheduleRepository.delete(schedule);
     }
 
@@ -135,12 +134,12 @@ public class ScheduleServiceImpl implements ScheduleService {
         }
     }
 
-    private void validateUserAccessToProject(Long userNo, Project project) {
+    private void validateUserAccessToTeam(Long userNo, Team team) {
         User user = userRepository.findById(userNo)
                 .orElseThrow(() -> new EntityNotFoundException("User not found with id: " + userNo));
 
         // 프로젝트 팀 멤버인지 확인하는 로직
-        boolean isMember = project.getTeam().getTeamUsers().stream()
+        boolean isMember = team.getTeamUsers().stream()
                 .anyMatch(teamUser -> teamUser.getUser().equals(user));
 
         if (!isMember) {


### PR DESCRIPTION
feat: 팀 일정 관리 시스템 구현

- Schedule 엔티티에 CRUD 기능 구현
- 팀별 일정 조회 기능 추가
- 일정 알림 시스템 구현(24시간 이내 마감 예정)
- Schedule-Team 양방향 연관관계 매핑

세부사항:
- ScheduleController에 일정 관리 REST API 엔드포인트 구현
- 일정 상태(PENDING) 관리 기능 추가
- QueryDSL을 활용한 일정 알림 조회 기능 구현